### PR TITLE
sstate: fix wrongly spelled sstate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,14 +81,13 @@ RUN chown -R $USERNAME:$USERNAME $WORKSPACE
 USER $USERNAME
 ENV PATH="${PATH}:/home/${USERNAME}/.local/bin"
 
-
 # Configure git so repo won't complain later on
 RUN git config --global user.name "${USERNAME}"
 RUN git config --global user.email "trs@linaro.org"
 
 RUN chmod a+x $WORKSPACE/trs-install.sh
 RUN ln -snf $HOME/yocto_cache/downloads $WORKSPACE/build/downloads
-RUN ln -snf $HOME/yocto_cache/state-cache $WORKSPACE/build/state-cache
+RUN ln -snf $HOME/yocto_cache/sstate-cache $WORKSPACE/build/sstate-cache
 
 ################################################################################
 # SSH configuration

--- a/run-trs.sh
+++ b/run-trs.sh
@@ -2,6 +2,7 @@
 
 IMAGE=trs
 export GID=$(id -g)
+export GID=$(id -u)
 REPO_REFERENCE=/tmp
 
 ################################################################################
@@ -31,8 +32,8 @@ fi
 
 if [ -z $SSTATE_DIR ]; then
 	echo "SSTATE_DIR not set, creating it under $HOME/yocto_cache"
-	mkdir -p $HOME/yocto_cache/state-cache
-	SSTATE_DIR=$HOME/yocto_cache/state-cache
+	mkdir -p $HOME/yocto_cache/sstate-cache
+	SSTATE_DIR=$HOME/yocto_cache/sstate-cache
 fi
 
 ################################################################################
@@ -40,6 +41,7 @@ fi
 ################################################################################
 echo "Running docker instance with params:"
 echo "IMAGE:          $IMAGE"
+echo "UID:            $UID"
 echo "GID:            $GID"
 echo "REPO_REFERENCE: $REPO_REFERENCE"
 echo "DL_DIR:         $DL_DIR"
@@ -48,6 +50,6 @@ echo "SSTATE_DIR:     $SSTATE_DIR"
 sudo docker run -it \
 	--user dev:$GID \
 	-v $DL_DIR:/home/dev/yocto_cache/downloads \
-	-v $SSTATE_DIR:/home/dev/yocto_cache/state-cache \
+	-v $SSTATE_DIR:/home/dev/yocto_cache/sstate-cache \
 	-v $REPO_REFERENCE:/home/dev/reference \
 	$IMAGE

--- a/trs-install.sh
+++ b/trs-install.sh
@@ -33,7 +33,7 @@ if [ -z $USE_HOST_YOCTO_CACHE ]; then
 else
 	echo "Using Yocto cache from host"
 	ln -snf $HOME/yocto_cache/downloads build/downloads
-	ln -snf $HOME/yocto_cache/state-cache build/state-cache
+	ln -snf $HOME/yocto_cache/sstate-cache build/sstate-cache
 fi
 
 ################################################################################


### PR DESCRIPTION
The Yocto caches wasn't working simply because the symlink created in the build folder had the wrong spelling.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>