### PR TITLE
run-trs.sh: Fix UID, GID issue

### DIFF
--- a/run-trs.sh
+++ b/run-trs.sh
@@ -2,7 +2,7 @@
 
 IMAGE=trs
 export GID=$(id -g)
-export GID=$(id -u)
+export UID=$(id -u)
 REPO_REFERENCE=/tmp
 
 ################################################################################


### PR DESCRIPTION
We currently don't use UID, but the current code incorrectly sets the GID to the UID.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>